### PR TITLE
image: update prepare-image for latest recovery dir layout

### DIFF
--- a/recovery/util.go
+++ b/recovery/util.go
@@ -32,6 +32,7 @@ func GetKernelParameter(name string) string {
 
 func globFile(dir, pattern string) string {
 	files, err := filepath.Glob(path.Join(dir, pattern))
+	fmt.Printf("glob %s %s found: %s (err %s)\n", dir, pattern, files, err)
 	if err != nil {
 		return ""
 	}
@@ -77,7 +78,7 @@ func mkdirs(base string, dirlist []string, mode os.FileMode) error {
 
 func copyTree(src, dst string) error {
 	// FIXME
-	logger.Noticef("copying %s", src)
+	logger.Noticef("copying %s to %s", src, dst)
 	if err := exec.Command("cp", "-rap", src, dst).Run(); err != nil {
 		return fmt.Errorf("cannot copy tree from %s to %s: %s", src, dst, err)
 	}


### PR DESCRIPTION
During the london sprint we decided on a new directory layout
for the UC20 ubuntu-seed (recovery) partition:

```
/systems/$date/{model,options.yaml,assertions/,/snaps/{for sideloaded-snaps...}}
/snaps/{pc_123.snap,pc-kernel_99.snap,...}
```

This PR implements this new dir layout. It also needs changes to the pc-gadget and to the initramfs code which will be proposed as well.